### PR TITLE
Add explicit installation of scipy version 1.8.1

### DIFF
--- a/ci/conda_requirements.txt
+++ b/ci/conda_requirements.txt
@@ -18,3 +18,4 @@ yaml
 pyyaml
 scikit-learn
 h5py
+scipy=1.8.1


### PR DESCRIPTION
Use scipy version 1.8.1 because it contains -unlike the newer versions of scipy-  the scipy.stats.PearsonRConstantInputWarning class that is requirred in ggmap

______________________________________________________________________________________ 
Patch notes of scipy 1.9.0 
(https://docs.scipy.org/doc/scipy-1.9.0/release.1.9.0.html?highlight=scipy%20stats%20pearsonrconstantinputwarning)

"Several function-specific warnings (F_onewayConstantInputWarning, F_onewayBadInputSizesWarning,
 PearsonRConstantInputWarning, PearsonRNearConstantInputWarning, SpearmanRConstantInputWarning,
 and BootstrapDegenerateDistributionWarning) have been replaced with more general warnings."